### PR TITLE
Fix GitHub Action Release 403 Error

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,6 +1,9 @@
 # The name of this action
 name: Compile Project to PDF
 
+permissions:
+  contents: write
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push to any tags
@@ -31,8 +34,7 @@ jobs:
         run: |
           wget -O cwTeXKai.ttf https://fonts.gstatic.com/ea/cwtexkai/v3/cwTeXKai-zhonly.ttf
           echo -e "\n\\usepackage{fontspec}" >> Config/fonts.tex
-          sed -i 's/標楷體/\[cwTexKai.ttf\]/1' Config/fonts.tex && cat Config/fonts.tex
-      
+          sed -i '/^\\zhFont/s/.*/\\zhFont{cwTexKai.ttf}/' Config/fonts.tex && cat Config/fonts.tex
       # This action is to install English font
       #   1. Accept the EULA that will pop-up during installation
       #   2. Install the font package
@@ -55,7 +57,7 @@ jobs:
       
       # This action is to create GitHub Releases
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         with:
           files: |
             main.pdf


### PR DESCRIPTION
![CleanShot 2023-05-06 at 16 44 09](https://user-images.githubusercontent.com/1254953/236613625-d3da5972-0f6b-48f8-8174-1de87bd87b5b.png)

問題主要是 release 需要 permission，另外也修了 fonts replace 並把 `softprops/action-gh-release` 升到最新版